### PR TITLE
Use Rust 1.23 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: rust:1.20
+      - image: rust:1.23
     steps:
       - checkout
       # Load cargo target from cache if possible.


### PR DESCRIPTION
Some dependencies won't build with older versions.